### PR TITLE
add user state periodic update

### DIFF
--- a/backend/src/auth/jwt_auth.ts
+++ b/backend/src/auth/jwt_auth.ts
@@ -31,11 +31,9 @@ export function check_admin(req, res, next) {
 }
 
 export function jwt_express_auth(req, res, next) {
-    console.log(req.headers)
     const authHeader  = req.headers['authorization'];
-    const authCookie = req.cookies['authorization'];
+    const authCookie = req.cookies['live-site-jwt'];
     const token = (authHeader && authHeader.split(" ")[1] ) || authCookie;
-    console.log(authHeader);
     if (token == null) return res.status(403).json({"error": "No access token provided"});
 
     verifyTokenAndGetUserState(token).catch((e) => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,7 +30,6 @@ app.post('/login', (req, res) => {
 
   authenticationServer.login(username, password).then((response) => {
     UserManager.getState(response.preferred_username).then(async (userState) => {
-      console.log(response.preferred_username);
       // if not registered
       if(!userState) {
         const res = await UserManager.addUser(response.preferred_username).catch((e) => {


### PR DESCRIPTION
Currently, in order to check whether an user is banned, the chat server has to call `UserManager.getState()` on every new message.
This is call is pretty expensive and too overkill for our usecase.

This commit implements a background routine to update UserState for all local sockets periodically. This allows us to achieve eventual consistency with the database (which in this case is the LocalUserManager), and reduces number of calls to `UserManager.getState()` significantlly

Test plan:
1. Try to ban an user in chat to see if the chatserver is able to pickup the ban request
2. Try to unban to see if the user is "eventually" unbanned from chat
3. Monitor server logs