### PR TITLE
Install design system using deploy key

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-**/node_modules
-
 # testing
 /coverage
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - hdoan/fix-install-design-system
 
 jobs:
   build:
@@ -14,12 +15,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.16'
-    # - name: Install and run unittest
-    #   run: |
-    #     npm install
-    #     npm test
-    #   env:
-    #     CI: true
+    - name: Install and run unittest
+      run: |
+        cd backend/
+        npm install
+        npm test
+        cd ../frontend
+        npm install
+        npm test
+      env:
+        CI: true
     - name: Publish to Github Packages Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,13 +16,12 @@ jobs:
       with:
         node-version: '12.16'
     - name: Install and run unittest
+      # TODO add tests and run here
       run: |
-        cd backend/
+        cd frontend/
         npm install
-        npm test
-        cd ../frontend
+        cd ../backend/
         npm install
-        npm test
       env:
         CI: true
     - name: Publish to Github Packages Registry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.16'
+    - uses: webfactory/ssh-agent@v0.4.0
+      with:
+        ssh-private-key: |
+          ${{ secrets.DESIGN_SYSTEM_DEPLOY_KEY }}
     - name: Install and run unittest
       # TODO add tests and run here
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Live-STEAM
 
-## Deployment instructions:
+## Auto deployment instructions:
+
+Currently, our app is configured to deploy to production with every changes on master
+1. Build a docker package and host it on github registry.
+2. SSH to the droplet and pull the package from github & run it on port 3600
+3. There is a Nginx server that proxy the requests to port 3600
+
+
+See the `.github/workflows/deploy.yml` for the build steps and `Dockerfile` for docker build steps
+
+
+## Manual deployment instructions (unused):
 
 1. Install docker-machine following [this guide](https://docs.docker.com/machine/install-machine/)
 2. Copy docker machine config to your laptop


### PR DESCRIPTION
- Add a deploy_key to the design-system repo
- Leverage https://github.com/webfactory/ssh-agent/ to add the private key to the build process
- For simplicity, copy node_modules from the build step to the docker

We could try passing the deploy secret key to docker container if we want to isolate the build steps. However, the current set up is faster because we only need to install node modules once and share between the build & test step and the build package step
https://github.com/webfactory/ssh-agent/issues/11